### PR TITLE
Fix get_acrossword_left

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -125,7 +125,7 @@ void get_acrossword(int row, int col, char *word) {
 }
 
 void get_acrossword_left(int row, int col, char *word) {
-        for (; rightof_tile(row, col); col--)
+        for (; leftof_tile(row, col); col--)
                 ;
         get_acrossword(row, col, word);
 }


### PR DESCRIPTION
Hey @edma2 thanks for sharing this package. I'm one of the creators of http://literakiapp.com (it's a word game similar to scrabble but for Polish dictionary). I'm in the process of writing a computer player based on  Jacobson and Appel paper in node.js and I ran into your repo which is very helpful. 

While testing it I noticed this little bug. If I understand correctly we should be moving left and grabbing the entire word (prefix) from the left. Is that correct? I know you wrote this 7 years ago so it's probably hard to remember ;)

